### PR TITLE
Various attribute datatypes support, MongoDB query builder fix

### DIFF
--- a/core/crce-metadata-api/src/main/java/cz/zcu/kiv/crce/metadata/impl/GenericAttributeType.java
+++ b/core/crce-metadata-api/src/main/java/cz/zcu/kiv/crce/metadata/impl/GenericAttributeType.java
@@ -27,6 +27,11 @@ public class GenericAttributeType implements AttributeType<Object> {
                 this.type = String.class;
                 break;
 
+            case "Boolean":
+            case "java.lang.Boolean":
+                this.type = Boolean.class;
+                break;
+
             case "Long":
             case "java.lang.Long":
                 this.type = Long.class;

--- a/core/crce-metadata-json-impl/src/main/java/cz/zcu/kiv/crce/metadata/json/internal/MetadataDeserializer.java
+++ b/core/crce-metadata-json-impl/src/main/java/cz/zcu/kiv/crce/metadata/json/internal/MetadataDeserializer.java
@@ -400,6 +400,11 @@ public class MetadataDeserializer {
                             callback.addAttribute(new SimpleAttributeType<>(name, String.class), valueNode.asText(), operator);
                             continue;
 
+                        case "Boolean":
+                        case "java.lang.Boolean":
+                            callback.addAttribute(new SimpleAttributeType<>(name, Boolean.class), valueNode.asBoolean(), operator);
+                            continue;
+
                         case "Long":
                         case "java.lang.Long":
                             callback.addAttribute(new SimpleAttributeType<>(name, Long.class), valueNode.asLong(), operator);
@@ -418,10 +423,6 @@ public class MetadataDeserializer {
                         case "List":
                         case "java.util.List":
                             callback.addAttribute(new ListAttributeType(name), deserializeList(valueNode), operator);
-                            continue;
-
-                        case "Boolean":
-                            callback.addAttribute(new SimpleAttributeType<>(name, Boolean.class), valueNode.asBoolean(), operator);
                             continue;
 
                         case "URI":

--- a/modules/crce-vo/src/main/java/cz/zcu/kiv/crce/vo/internal/dozer/convertor/RequirementConvertor.java
+++ b/modules/crce-vo/src/main/java/cz/zcu/kiv/crce/vo/internal/dozer/convertor/RequirementConvertor.java
@@ -1,5 +1,7 @@
 package cz.zcu.kiv.crce.vo.internal.dozer.convertor;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -13,6 +15,7 @@ import cz.zcu.kiv.crce.metadata.AttributeType;
 import cz.zcu.kiv.crce.metadata.MetadataFactory;
 import cz.zcu.kiv.crce.metadata.Requirement;
 import cz.zcu.kiv.crce.metadata.impl.GenericAttributeType;
+import cz.zcu.kiv.crce.metadata.type.Version;
 import cz.zcu.kiv.crce.vo.model.metadata.AttributeVO;
 import cz.zcu.kiv.crce.vo.model.metadata.DirectiveVO;
 import cz.zcu.kiv.crce.vo.model.metadata.GenericRequirementVO;
@@ -99,9 +102,26 @@ public class RequirementConvertor extends DozerConverter<Requirement, GenericReq
      */
     private Object retype(String type, String value) {
         switch (type) {
+            default:
+            case "String":
+            case "java.lang.String":
+                return value;
+
             case "Boolean":
             case "java.lang.Boolean":
                 return Boolean.valueOf(value);
+
+            case "Long":
+            case "java.lang.Long":
+                return Long.valueOf(value);
+
+            case "Double":
+            case "java.lang.Double":
+                return Double.valueOf(value);
+
+            case "Version":
+            case "cz.zcu.kiv.crce.metadata.type.Version":
+                return new Version(value);
 
             case "List":
             case "java.util.List":
@@ -111,8 +131,13 @@ public class RequirementConvertor extends DozerConverter<Requirement, GenericReq
                     return Arrays.asList(value.split(","));
                 }
 
-            default:
-                return value;
+            case "URI":
+            case "java.net.URI":
+                try {
+                    return new URI(value);
+                } catch (URISyntaxException ex) {
+                    throw new IllegalArgumentException("Invalid URI: " + value, ex);
+                }
         }
     }
 


### PR DESCRIPTION
Two issues are addressed in this pull request (sorry about that):

1. various attribute datatypes support - When mapped from incoming API request, `AttributeVO` was incorrectly created with value of `java.lang.String` datatype (except for `java.util.List`) no matter what type was set in `attribute.getType()`.
2. MongoDB query builder fix - Queries were build incorrectly using some kind of prefix to match objects within arrays. MongoDB's `elemMatch` is used instead.