### PR TITLE
Fixes for issue #31 and for issues with javax.annotation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ On linux, step 3. can be perfomed via `.../third-party$ for d in * ; do cd $d ; 
 
 ## Start up
 
-To start on local machine, run CRCE using Maven plugin for pax in `crce-modules-reactor` module (i.e. `/deploy` directory):
+To start on local machine, make sure the `/deploy/conf` folder exists and contains all important configuration (especially the `cz.zcu.kiv.crce.repository.filebased-store.cfg`. After that, you run CRCE using Maven plugin for pax in `crce-modules-reactor` module (i.e. `/deploy` directory):
 
 ```mvn pax:provision```
 
@@ -87,3 +87,11 @@ To solve the issue with mathematical solver, you need to install [lpsolve librar
 ## Code updates
 
 After modifying a part of code, only the parental module needs to be rebuilt (no need to rebuild all). After that, the pax process must be restarted.
+
+
+## Configuration
+
+Configuration is done via OSGI service called [Configuration Admin](https://osgi.org/specification/osgi.cmpn/7.0.0/service.cm.html). 
+Details on how it's implemented in Felix can be found in  [Apache Felix Configuration Admin Service](https://felix.apache.org/documentation/subprojects/apache-felix-config-admin.html).
+
+By default, Felix will look into the `conf` directory for possible configuration (example of such directory can be found in `deploy/conf.default`)

--- a/build/compiled/pom.xml
+++ b/build/compiled/pom.xml
@@ -126,20 +126,6 @@
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>
-
-        <!-- crce-webui -->
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,19 +6,26 @@ RUN mkdir /felix
 WORKDIR /felix
 
 # Download and upack Felix
-# 4.6.1 is compatible with Java 1.7
-ADD https://archive.apache.org/dist/felix/org.apache.felix.main.distribution-5.0.0.tar.gz ./apache-felix.tar.gz
+ADD https://archive.apache.org/dist/felix/org.apache.felix.main.distribution-6.0.3.tar.gz ./apache-felix.tar.gz
 RUN tar xvfz apache-felix.tar.gz && rm apache-felix.tar.gz
-ENV FELIX_PATH /felix/felix-framework-5.0.0
+ENV FELIX_PATH /felix/felix-framework-6.0.3
 
 # Remove duplicate gogo runtime
-RUN rm ${FELIX_PATH}/bundle/org.apache.felix.gogo.runtime-0.16.2.jar
+RUN rm ${FELIX_PATH}/bundle/org.apache.felix.gogo.runtime*
 
 # Add CRCE modules to Felix autodeploy dir
 ADD ./target/pax-runner-dir/bundles/* ${FELIX_PATH}/bundle/
 
 # Create directory for installing new bundles
 RUN mkdir ${FELIX_PATH}/dist
+
+# Copy configuration for Configuration Admin service
+# 'conf' is the directory to watch (configured by 'felix.fileinstall.dir')
+#RUN mkdir ${FELIX_PATH}/load
+ADD ./conf/* ${FELIX_PATH}/conf/
+
+# Felix framework configuration override
+COPY ./felix-configuration/config.properties ${FELIX_PATH}/conf/
 
 # Set environmental variable for connection string to mongodb
 ENV mongo_connection mongodb://mongoserver:27017

--- a/deploy/Readme.md
+++ b/deploy/Readme.md
@@ -1,0 +1,23 @@
+# Contents
+
+This directory contains files needed to create runnable docker image with application.
+
+## Provision module
+
+Module used to gather all necessary bundles from application.
+
+## conf.default and conf directories
+
+Folder containing configuration files for Configuration Admin service. Since the application
+is running in docker, only inside-the-container configuration should be passed (file storage, log levels, ...)
+but not outside-the-container configuration such as database connection details.
+
+If the `conf` directory doesn't exist, be sure to create it. You can just copy the `conf.default`.
+
+## Dockerfile
+
+File used to create docker image.
+
+## felix-configuration directory
+
+Felix framework configuration files.

--- a/deploy/felix-configuration/config.properties
+++ b/deploy/felix-configuration/config.properties
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# Framework config properties.
+#
+
+# To override the packages the framework exports by default from the
+# class path, set this variable.
+#org.osgi.framework.system.packages=
+
+# To append packages to the default set of exported system packages,
+# set this value.
+#org.osgi.framework.system.packages.extra=
+
+# The following property makes specified packages from the class path
+# available to all bundles. You should avoid using this property.
+#org.osgi.framework.bootdelegation=sun.*,com.sun.*
+
+# Felix tries to guess when to implicitly boot delegate in certain
+# situations to ease integration without outside code. This feature
+# is enabled by default, uncomment the following line to disable it.
+#felix.bootdelegation.implicit=false
+
+# The following property explicitly specifies the location of the bundle
+# cache, which defaults to "felix-cache" in the current working directory.
+# If this value is not absolute, then the felix.cache.rootdir controls
+# how the absolute location is calculated. (See next property)
+#org.osgi.framework.storage=${felix.cache.rootdir}/felix-cache
+
+# The following property is used to convert a relative bundle cache
+# location into an absolute one by specifying the root to prepend to
+# the relative cache path. The default for this property is the
+# current working directory.
+#felix.cache.rootdir=${user.dir}
+
+# The following property controls whether the bundle cache is flushed
+# the first time the framework is initialized. Possible values are
+# "none" and "onFirstInit"; the default is "none".
+#org.osgi.framework.storage.clean=onFirstInit
+
+# The following property determines which actions are performed when
+# processing the auto-deploy directory. It is a comma-delimited list of
+# the following values: 'install', 'start', 'update', and 'uninstall'.
+# An undefined or blank value is equivalent to disabling auto-deploy
+# processing.
+felix.auto.deploy.action=install,start
+
+# The following property specifies the directory to use as the bundle
+# auto-deploy directory; the default is 'bundle' in the working directory.
+#felix.auto.deploy.dir=bundle
+
+# The following property is a space-delimited list of bundle URLs
+# to install when the framework starts. The ending numerical component
+# is the target start level. Any number of these properties may be
+# specified for different start levels.
+#felix.auto.install.1=
+
+# The following property is a space-delimited list of bundle URLs
+# to install and start when the framework starts. The ending numerical
+# component is the target start level. Any number of these properties
+# may be specified for different start levels.
+#felix.auto.start.1=
+
+felix.log.level=1
+
+# Sets the initial start level of the framework upon startup.
+#org.osgi.framework.startlevel.beginning=1
+
+# Sets the start level of newly installed bundles.
+#felix.startlevel.bundle=1
+
+# Felix installs a stream and content handler factories by default,
+# uncomment the following line to not install them.
+#felix.service.urlhandlers=false
+
+# The launcher registers a shutdown hook to cleanly stop the framework
+# by default, uncomment the following line to disable it.
+#felix.shutdown.hook=false
+
+#
+# Bundle config properties.
+#
+
+org.osgi.service.http.port=8080
+obr.repository.url=http://felix.apache.org/obr/releases.xml
+
+#
+# Configuration Admin service settings
+#
+felix.cm.loglevel=4
+
+# Directory to place configuration files for Configuration admin into
+# default value is ./load
+# Files in this directory are watched and periodically polled for changes
+felix.fileinstall.dir=./conf
+
+#
+# Place any other parameters here
+#

--- a/modules/crce-external-repository/pom.xml
+++ b/modules/crce-external-repository/pom.xml
@@ -206,11 +206,6 @@
 				<artifactId>sisu-guice</artifactId>
 				<version>3.2.6</version>
 			</dependency>
-			<dependency>
-				<groupId>javax.annotation</groupId>
-				<artifactId>javax.annotation-api</artifactId>
-				<version>1.2</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
@@ -358,10 +353,6 @@
 		<dependency>
 			<groupId>org.sonatype.sisu</groupId>
 			<artifactId>sisu-guice</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/modules/crce-metadata-osgi-bundle/pom.xml
+++ b/modules/crce-metadata-osgi-bundle/pom.xml
@@ -59,13 +59,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>cz.zcu.kiv.crce</groupId>
-            <artifactId>crce-metadata-impl</artifactId>
-            <version>3.0.1-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
All fixes related to Java 8.

Contains:
 - Readme update
 - Configuration cleanup
 - Dockerfile update

Full clean build done, works with Docker and pax:provision. Both UI and REST API tested.